### PR TITLE
Added docker install for Trixie error

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Any installation will need to start with these steps:
     sh get-docker.sh
     ```
 
+    **NOTE**: If using Trixie and you get the error "E: The repository 'https://download.docker.com/linux/raspbian trixie Release' does not have a Release file. ", try:
+   ```bash
+   sudo apt install docker.io
+   ```
     Then add the current user to the "docker" group. This will enable us to run "docker" commands without sudo.
     ```bash
     sudo usermod -aG docker $USER


### PR DESCRIPTION
In the installation instructions I added a line for Trixie lite os on raspberry pi zero for docker install.